### PR TITLE
ENH: expose labels, refactor plot computation internals, add additional metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Clustergram is a diagram proposed by Matthias Schonlau in his paper *[The cluste
 
 The clustergram was later implemented in R by [Tal Galili](https://www.r-statistics.com/2010/06/clustergram-visualization-and-diagnostics-for-cluster-analysis-r-code/), who also gives a thorough explanation of the concept.
 
-This is a Python translation of Tal's script written for `scikit-learn` and RAPIDS `cuML` implementations of K-Means and Gaussian Mixture Model (scikit-learn only) clustering.
+This is a Python translation of Tal's script written for `scikit-learn` and RAPIDS `cuML` implementations of K-Means, Mini Batch K-Means and Gaussian Mixture Model (scikit-learn only) clustering.
 
 ## Getting started
 
@@ -24,7 +24,7 @@ conda install clustergram -c conda-forge
 pip install clustergram
 ```
 
-In any case, you still need to install your selected backend 
+In any case, you still need to install your selected backend
 (`scikit-learn` or `cuML`).
 
 The example of clustergram on Palmer penguins dataset:
@@ -76,16 +76,16 @@ cgram.plot(
 On the `y` axis, a clustergram can use mean values as in the original paper by Matthias Schonlau or PCA weighted mean values as in the implementation by Tal Galili.
 
 ```python
-cgram = Clustergram(range(1, 8), pca_weighted=True)
+cgram = Clustergram(range(1, 8))
 cgram.fit(data)
-cgram.plot(figsize=(12, 8))
+cgram.plot(figsize=(12, 8), pca_weighted=True)
 ```
 ![Default clustergram](https://raw.githubusercontent.com/martinfleis/clustergram/master/doc/_static/pca_true.png)
 
 ```python
-cgram = Clustergram(range(1, 8), pca_weighted=False)
+cgram = Clustergram(range(1, 8))
 cgram.fit(data)
-cgram.plot(figsize=(12, 8))
+cgram.plot(figsize=(12, 8), pca_weighted=False)
 ```
 ![Default clustergram](https://raw.githubusercontent.com/martinfleis/clustergram/master/doc/_static/pca_false.png)
 
@@ -93,7 +93,7 @@ cgram.plot(figsize=(12, 8))
 
 Clustergram offers two backends for the computation - `scikit-learn` which uses CPU and RAPIDS.AI `cuML`, which uses GPU. Note that both are optional dependencies, but you will need at least one of them to generate clustergram.
 
-Using scikit-learn (default):
+Using `scikit-learn` (default):
 
 ```python
 cgram = Clustergram(range(1, 8), backend='sklearn')
@@ -101,7 +101,7 @@ cgram.fit(data)
 cgram.plot()
 ```
 
-Using cuML:
+Using `cuML`:
 
 ```python
 cgram = Clustergram(range(1, 8), backend='cuML')
@@ -113,7 +113,7 @@ cgram.plot()
 
 ## Supported methods
 
-Clustergram currently supports K-Means and Gaussian Mixture Model clustering methods. Note tha GMM and Mini Batch K-Means are supported only for `scikit-learn` backend.
+Clustergram currently supports K-Means, Mini Batch K-Means and Gaussian Mixture Model clustering methods. Note tha GMM and Mini Batch K-Means are supported only for `scikit-learn` backend.
 
 Using K-Means (default):
 
@@ -154,6 +154,79 @@ cgram.plot(figsize=(12, 8))
 cgram.plot(k_range=range(3, 10), figsize=(12, 8))
 ```
 ![Limited clustergram](https://raw.githubusercontent.com/martinfleis/clustergram/master/doc/_static/limited_plot.png)
+
+## Additional clustering performance evaluation
+
+Clustergam includes handy wrappers around a selection of clustering performance metrics offered by
+`scikit-learn`. Data which were originally computed on GPU are converted to numpy on the fly.
+
+### Silhouette score
+
+Compute the mean Silhouette Coefficient of all samples. See [`scikit-learn` documentation](https://scikit-learn.org/stable/modules/generated/sklearn.metrics.silhouette_score.html#sklearn.metrics.silhouette_score) for details.
+
+```python
+>>> cgram.silhouette_score()
+2    0.531540
+3    0.447219
+4    0.400154
+5    0.377720
+6    0.372128
+7    0.331575
+Name: silhouette_score, dtype: float64
+```
+Once computed, resulting Series is available as `cgram.silhouette`. Calling the original method will recompute the score.
+
+### Calinski and Harabasz score
+
+Compute the Calinski and Harabasz score, also known as the Variance Ratio Criterion. See [`scikit-learn` documentation](https://scikit-learn.org/stable/modules/generated/sklearn.metrics.calinski_harabasz_score.html#sklearn.metrics.calinski_harabasz_score) for details.
+
+```python
+>>> cgram.calinski_harabasz_score()
+2    482.191469
+3    441.677075
+4    400.392131
+5    411.175066
+6    382.731416
+7    352.447569
+Name: calinski_harabasz_score, dtype: float64
+```
+Once computed, resulting Series is available as `cgram.calinski_harabasz`. Calling the original method will recompute the score.
+
+### Davies-Bouldin score
+
+Compute the Davies-Bouldin score. See [`scikit-learn` documentation](https://scikit-learn.org/stable/modules/generated/sklearn.metrics.davies_bouldin_score.html#sklearn.metrics.davies_bouldin_score) for details.
+
+```python
+>>> cgram.davies_bouldin_score()
+2    0.714064
+3    0.943553
+4    0.943320
+5    0.973248
+6    0.950910
+7    1.074937
+Name: davies_bouldin_score, dtype: float64
+```
+Once computed, resulting Series is available as `cgram.davies_bouldin`. Calling the original method will recompute the score.
+
+## Acessing labels
+
+`Clustergram` stores resulting labels for each of the tested options, which can be accessed as:
+
+```python
+>>> cgram.labels
+     1  2  3  4  5  6  7
+0    0  0  2  2  3  2  1
+1    0  0  2  2  3  2  1
+2    0  0  2  2  3  2  1
+3    0  0  2  2  3  2  1
+4    0  0  2  2  0  0  3
+..  .. .. .. .. .. .. ..
+337  0  1  1  3  2  5  0
+338  0  1  1  3  2  5  0
+339  0  1  1  1  1  1  4
+340  0  1  1  3  2  5  5
+341  0  1  1  1  1  1  5
+```
 
 ## Saving clustergram
 

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ cgram.plot()
 Using Mini Batch K-Means, which can provide significant speedup over K-Means:
 
 ```python
-cgram = Clustergram(range(1, 8), method='minibatchkmeans')
+cgram = Clustergram(range(1, 8), method='minibatchkmeans', batch_size=100)
 cgram.fit(data)
 cgram.plot()
 ```

--- a/clustergram/clustergram.py
+++ b/clustergram/clustergram.py
@@ -33,7 +33,7 @@ class Clustergram:
     Parameters
     ----------
     k_range : iterable
-        iterable of integer values to be tested as k.
+        iterable of integer values to be tested as ``k``.
     backend : {'sklearn', 'cuML'} (default 'sklearn')
         Whether to use ``sklearn``'s implementation of KMeans and PCA or ``cuML``
         version. ``sklearn`` does computation on CPU, ``cuml`` on GPU.
@@ -111,6 +111,15 @@ class Clustergram:
         self.engine_kwargs = kwargs
         self.verbose = verbose
 
+        if self.backend == "sklearn":
+            self.plot_data_pca = pd.DataFrame()
+            self.plot_data = pd.DataFrame()
+        else:
+            import cudf
+
+            self.plot_data_pca = cudf.DataFrame()
+            self.plot_data = cudf.DataFrame()
+
     def __repr__(self):
         return (
             f"Clustergram(k_range={self.k_range}, backend='{self.backend}', "
@@ -174,7 +183,7 @@ class Clustergram:
     def _kmeans_cuml(self, data, **kwargs):
         """Use cuML KMeans"""
         try:
-            from cuml import KMeans, PCA
+            from cuml import KMeans
             import cudf
         except ImportError:
             raise ImportError(
@@ -191,7 +200,6 @@ class Clustergram:
             self.cluster_centers[n] = results.cluster_centers_
 
             print(f"K={n} fitted in {time() - s} seconds.") if self.verbose else None
-        return df
 
     def _gmm_sklearn(self, data, **kwargs):
         """Use sklearn.mixture.GaussianMixture"""
@@ -398,15 +406,6 @@ class Clustergram:
         -------
         ax : matplotlib axis instance
         """
-        if self.backend == "sklearn":
-            self.plot_data_pca = pd.DataFrame()
-            self.plot_data = pd.DataFrame()
-        else:
-            import cudf
-
-            self.plot_data_pca = cudf.DataFrame()
-            self.plot_data = cudf.DataFrame()
-
         if pca_weighted:
             if self.plot_data_pca.empty:
                 pca_kwargs.pop("n_components", None)

--- a/clustergram/test_clustergram.py
+++ b/clustergram/test_clustergram.py
@@ -61,8 +61,12 @@ def test_sklearn_kmeans():
     ax = clustergram.plot(pca_weighted=False)
     ax.get_geometry() == (1, 1, 1)
 
-    assert clustergram.plot_data_pca.mean().mean() == -0.21726383145643727
-    assert clustergram.plot_data.mean().mean() == 2.3448529748438847
+    assert clustergram.plot_data_pca.mean().mean() == pytest.approx(
+        -0.21726383145643727, rel=1e-15
+    )
+    assert clustergram.plot_data.mean().mean() == pytest.approx(
+        2.3448529748438847, rel=1e-15
+    )
 
 
 def test_sklearn_minibatchkmeans():
@@ -100,8 +104,12 @@ def test_sklearn_minibatchkmeans():
     ax = clustergram.plot(pca_weighted=False)
     ax.get_geometry() == (1, 1, 1)
 
-    assert clustergram.plot_data_pca.mean().mean() == -0.19729006113986378
-    assert clustergram.plot_data.mean().mean() == 2.3478208185941405
+    assert clustergram.plot_data_pca.mean().mean() == pytest.approx(
+        -0.19729006113986378, rel=1e-15
+    )
+    assert clustergram.plot_data.mean().mean() == pytest.approx(
+        2.3478208185941405, rel=1e-15
+    )
 
 
 def test_sklearn_gmm():
@@ -136,8 +144,12 @@ def test_sklearn_gmm():
     ax = clustergram.plot(pca_weighted=False)
     ax.get_geometry() == (1, 1, 1)
 
-    assert clustergram.plot_data_pca.mean().mean() == -0.5578663671008622
-    assert clustergram.plot_data.mean().mean() == 2.300054613897816
+    assert clustergram.plot_data_pca.mean().mean() == pytest.approx(
+        -0.5578663671008622, rel=1e-15
+    )
+    assert clustergram.plot_data.mean().mean() == pytest.approx(
+        2.300054613897816, rel=1e-15
+    )
 
 
 @pytest.mark.skipif(
@@ -161,26 +173,29 @@ def test_cuml_kmeans():
     data = cudf.DataFrame(device_data)
 
     # cudf.DataFrame
-    clustergram = Clustergram(range(1, 10), backend="cuML", random_state=random_state)
+    clustergram = Clustergram(range(1, 8), backend="cuML", random_state=random_state)
     clustergram.fit(data)
 
     pd.testing.assert_series_equal(
         clustergram.labels.mean().to_pandas(),
-        pd.Series([0.0, 0.2, 0.6, 1.8, 2.0, 2.2, 2.7], index=range(1, 8)),
+        pd.Series([0, 0.7, 0.9, 1.8, 2, 1.6, 2.2], index=range(1, 8)),
     )
     assert clustergram.labels.shape == (10, 7)
     assert clustergram.labels.notna().all().all()
 
     expected = [
-        2.3448529748438847,
-        2.793993337861089,
-        2.8270525934022026,
-        2.513999519667852,
-        2.344852974843884,
-        2.059790669470653,
-        2.271614946625764,
+        3.7674055099487305,
+        2.7064273357391357,
+        3.451129913330078,
+        4.223802089691162,
+        4.125243663787842,
+        2.953890800476074,
+        3.4818685054779053,
     ]
-    assert expected == [cp.mean(clustergram.cluster_centers[x]) for x in range(1, 8)]
+    assert expected == [
+        pytest.approx(float(clustergram.cluster_centers[x].mean().mean()), rel=1e-6)
+        for x in range(1, 8)
+    ]
 
     assert clustergram.plot_data_pca.empty
     ax = clustergram.plot(pca_kwargs=dict(random_state=random_state))
@@ -190,32 +205,39 @@ def test_cuml_kmeans():
     ax = clustergram.plot(pca_weighted=False)
     ax.get_geometry() == (1, 1, 1)
 
-    assert clustergram.plot_data_pca.mean().mean() == -0.21726383145643727
-    assert clustergram.plot_data.mean().mean() == 2.3448529748438847
+    assert clustergram.plot_data_pca.mean().mean() == pytest.approx(
+        1.1016593081610544, rel=1e-15
+    )
+    assert clustergram.plot_data.mean().mean() == pytest.approx(
+        3.7674053737095425, rel=1e-15
+    )
 
     # cupy array
     data = device_data
 
-    clustergram = Clustergram(range(1, 10), backend="cuML")
+    clustergram = Clustergram(range(1, 8), backend="cuML", random_state=random_state)
     clustergram.fit(data)
 
     pd.testing.assert_series_equal(
         clustergram.labels.mean().to_pandas(),
-        pd.Series([0.0, 0.2, 0.6, 1.8, 2.0, 2.2, 2.7], index=range(1, 8)),
+        pd.Series([0, 0.7, 0.9, 1.8, 2, 1.6, 2.2], index=range(1, 8)),
     )
     assert clustergram.labels.shape == (10, 7)
     assert clustergram.labels.notna().all().all()
 
     expected = [
-        2.3448529748438847,
-        2.793993337861089,
-        2.8270525934022026,
-        2.513999519667852,
-        2.344852974843884,
-        2.059790669470653,
-        2.271614946625764,
+        3.7674055099487305,
+        2.7064273357391357,
+        3.451129913330078,
+        4.223802089691162,
+        4.125243663787842,
+        2.953890800476074,
+        3.4818685054779053,
     ]
-    assert expected == [cp.mean(clustergram.cluster_centers[x]) for x in range(1, 8)]
+    assert expected == [
+        pytest.approx(float(cp.mean(clustergram.cluster_centers[x])), rel=1e-6)
+        for x in range(1, 8)
+    ]
 
     assert clustergram.plot_data_pca.empty
     ax = clustergram.plot(pca_kwargs=dict(random_state=random_state))
@@ -225,8 +247,12 @@ def test_cuml_kmeans():
     ax = clustergram.plot(pca_weighted=False)
     ax.get_geometry() == (1, 1, 1)
 
-    assert clustergram.plot_data_pca.mean().mean() == -0.21726383145643727
-    assert clustergram.plot_data.mean().mean() == 2.3448529748438847
+    assert clustergram.plot_data_pca.mean().mean() == pytest.approx(
+        1.1016593081610544, rel=1e-15
+    )
+    assert clustergram.plot_data.mean().mean() == pytest.approx(
+        3.7674053737095425, rel=1e-15
+    )
 
 
 def test_errors():
@@ -262,6 +288,51 @@ def test_silhouette_score():
         clustergram.silhouette,
         pd.Series(
             [0.70244987, 0.64427202, 0.76772759, 0.94899084, 0.76998519, 0.57564372],
+            index=list(range(2, 8)),
+            name="silhouette_score",
+        ),
+    )
+
+
+@pytest.mark.skipif(
+    not RAPIDS, reason="RAPIDS not available.",
+)
+def test_silhouette_score_cuml():
+    n_samples = 10
+    n_features = 2
+
+    n_clusters = 5
+    random_state = 0
+
+    device_data, device_labels = cuml.make_blobs(
+        n_samples=n_samples,
+        n_features=n_features,
+        centers=n_clusters,
+        random_state=random_state,
+        cluster_std=0.1,
+    )
+
+    data = cudf.DataFrame(device_data)
+
+    clustergram = Clustergram(range(1, 8), backend="cuML", random_state=random_state)
+    clustergram.fit(data)
+
+    pd.testing.assert_series_equal(
+        clustergram.silhouette_score(),
+        pd.Series(
+            [0.7494349479675293, 0.9806153178215027, 0.6721830368041992, 0.39418715238571167, 0.44574037194252014, 0.08033210784196854],
+            index=list(range(2, 8)),
+            name="silhouette_score",
+        ),
+    )
+
+    clustergram = Clustergram(range(1, 8), backend="cuML", random_state=random_state)
+    clustergram.fit(device_data)
+
+    pd.testing.assert_series_equal(
+        clustergram.silhouette_score(),
+        pd.Series(
+            [0.7494349479675293, 0.9806153178215027, 0.6721830368041992, 0.39418715238571167, 0.44574037194252014, 0.08033210784196854],
             index=list(range(2, 8)),
             name="silhouette_score",
         ),
@@ -305,6 +376,51 @@ def test_calinski_harabasz_score():
     )
 
 
+@pytest.mark.skipif(
+    not RAPIDS, reason="RAPIDS not available.",
+)
+def test_calinski_harabasz_score_cuml():
+    n_samples = 10
+    n_features = 2
+
+    n_clusters = 5
+    random_state = 0
+
+    device_data, device_labels = cuml.make_blobs(
+        n_samples=n_samples,
+        n_features=n_features,
+        centers=n_clusters,
+        random_state=random_state,
+        cluster_std=0.1,
+    )
+
+    data = cudf.DataFrame(device_data)
+
+    clustergram = Clustergram(range(1, 8), backend="cuML", random_state=random_state)
+    clustergram.fit(data)
+
+    pd.testing.assert_series_equal(
+        clustergram.calinski_harabasz_score(),
+        pd.Series(
+            [25.619150510634366, 15374.042816067375, 10813.16845006968, 8818.1163716754, 8070.657293970755, 7259.89764652579],
+            index=list(range(2, 8)),
+            name="calinski_harabasz_score",
+        ),
+    )
+
+    clustergram = Clustergram(range(1, 8), backend="cuML", random_state=random_state)
+    clustergram.fit(device_data)
+
+    pd.testing.assert_series_equal(
+        clustergram.calinski_harabasz_score(),
+        pd.Series(
+            [25.619150510634366, 15374.042816067375, 10813.16845006968, 8818.1163716754, 8070.657293970755, 7259.89764652579],
+            index=list(range(2, 8)),
+            name="calinski_harabasz_score",
+        ),
+    )
+
+
 def test_davies_bouldin_score():
     clustergram = Clustergram(range(1, 8), backend="sklearn", random_state=random_state)
     clustergram.fit(data)
@@ -322,6 +438,51 @@ def test_davies_bouldin_score():
         clustergram.davies_bouldin,
         pd.Series(
             [0.2493657, 0.35181197, 0.34758021, 0.05567944, 0.03051626, 0.02520726],
+            index=list(range(2, 8)),
+            name="davies_bouldin_score",
+        ),
+    )
+
+
+@pytest.mark.skipif(
+    not RAPIDS, reason="RAPIDS not available.",
+)
+def test_davies_bouldin_score_cuml():
+    n_samples = 10
+    n_features = 2
+
+    n_clusters = 5
+    random_state = 0
+
+    device_data, device_labels = cuml.make_blobs(
+        n_samples=n_samples,
+        n_features=n_features,
+        centers=n_clusters,
+        random_state=random_state,
+        cluster_std=0.1,
+    )
+
+    data = cudf.DataFrame(device_data)
+
+    clustergram = Clustergram(range(1, 8), backend="cuML", random_state=random_state)
+    clustergram.fit(data)
+
+    pd.testing.assert_series_equal(
+        clustergram.davies_bouldin_score(),
+        pd.Series(
+            [0.3107512701086121, 0.02263161666570639, 0.2261582258142144, 0.3839688146565784, 0.13388392354928222, 0.279734367840293],
+            index=list(range(2, 8)),
+            name="davies_bouldin_score",
+        ),
+    )
+
+    clustergram = Clustergram(range(1, 8), backend="cuML", random_state=random_state)
+    clustergram.fit(device_data)
+
+    pd.testing.assert_series_equal(
+        clustergram.davies_bouldin_score(),
+        pd.Series(
+            [0.3107512701086121, 0.02263161666570639, 0.2261582258142144, 0.3839688146565784, 0.13388392354928222, 0.279734367840293],
             index=list(range(2, 8)),
             name="davies_bouldin_score",
         ),

--- a/clustergram/test_clustergram.py
+++ b/clustergram/test_clustergram.py
@@ -1,10 +1,12 @@
 from sklearn.datasets import make_blobs
 import pandas as pd
+import numpy as np
 import pytest
 
 try:
     import cudf
     import cuml
+    import cupy as cp
 
     RAPIDS = True
 except (ImportError, ModuleNotFoundError):
@@ -12,7 +14,7 @@ except (ImportError, ModuleNotFoundError):
 
 from clustergram import Clustergram
 
-n_samples = 1000
+n_samples = 10
 n_features = 2
 
 n_clusters = 5
@@ -30,171 +32,119 @@ data = pd.DataFrame(device_data)
 
 
 def test_sklearn_kmeans():
-    clustergram = Clustergram(range(1, 10), backend="sklearn")
+    clustergram = Clustergram(range(1, 8), backend="sklearn", random_state=random_state)
     clustergram.fit(data)
 
     pd.testing.assert_series_equal(
-        clustergram.means.mean(),
-        pd.Series(
-            [
-                -0.30042205,
-                -0.30042205,
-                -0.30042205,
-                -0.30042205,
-                -0.30042205,
-                -0.30046431,
-                -0.3003699,
-                -0.30086877,
-                -0.30016977,
-            ],
-            index=list(range(1, 10)),
-        ),
-        rtol=6,
+        clustergram.labels.mean(),
+        pd.Series([0.0, 0.2, 0.6, 1.8, 2.0, 2.2, 2.7], index=range(1, 8)),
     )
+    assert clustergram.labels.shape == (10, 7)
+    assert clustergram.labels.notna().all().all()
 
-    ax = clustergram.plot()
+    expected = [
+        2.3448529748438847,
+        2.793993337861089,
+        2.8270525934022026,
+        2.513999519667852,
+        2.344852974843884,
+        2.059790669470653,
+        2.271614946625764,
+    ]
+    assert expected == [np.mean(clustergram.cluster_centers[x]) for x in range(1, 8)]
+
+    assert clustergram.plot_data_pca.empty
+    ax = clustergram.plot(pca_kwargs=dict(random_state=random_state))
     ax.get_geometry() == (1, 1, 1)
 
-    clustergram = Clustergram(range(1, 10), backend="sklearn", pca_weighted=False)
-    clustergram.fit(device_data)
-
-    pd.testing.assert_series_equal(
-        clustergram.means.mean(),
-        pd.Series(
-            [
-                2.05533664,
-                2.05533664,
-                2.05533664,
-                2.05533664,
-                2.05533664,
-                2.05522513,
-                2.05582383,
-                2.05585776,
-                2.05591782,
-            ],
-            index=list(range(1, 10)),
-        ),
-        rtol=6,
-    )
-
-    ax = clustergram.plot()
+    assert clustergram.plot_data.empty
+    ax = clustergram.plot(pca_weighted=False)
     ax.get_geometry() == (1, 1, 1)
+
+    assert clustergram.plot_data_pca.mean().mean() == -0.21726383145643727
+    assert clustergram.plot_data.mean().mean() == 2.3448529748438847
 
 
 def test_sklearn_minibatchkmeans():
-    clustergram = Clustergram(range(1, 10), backend="sklearn", method="minibatchkmeans")
+    clustergram = Clustergram(
+        range(1, 8),
+        backend="sklearn",
+        method="minibatchkmeans",
+        random_state=random_state,
+    )
     clustergram.fit(data)
 
     pd.testing.assert_series_equal(
-        clustergram.means.mean(),
-        pd.Series(
-            [
-                -0.30042205,
-                -0.30042205,
-                -0.30042205,
-                -0.30042205,
-                -0.30042205,
-                -0.30046431,
-                -0.3003699,
-                -0.30086877,
-                -0.30016977,
-            ],
-            index=list(range(1, 10)),
-        ),
-        rtol=6,
+        clustergram.labels.mean(),
+        pd.Series([0.0, 0.2, 0.6, 1.2, 2.0, 2.1, 2.6], index=range(1, 8)),
     )
+    assert clustergram.labels.shape == (10, 7)
+    assert clustergram.labels.notna().all().all()
 
-    ax = clustergram.plot()
+    expected = [
+        2.35104516103195,
+        2.7950777425566464,
+        2.8277733533088534,
+        2.522309579003138,
+        2.3452078554650075,
+        2.0602593594306526,
+        2.2717280475246584,
+    ]
+    assert expected == [np.mean(clustergram.cluster_centers[x]) for x in range(1, 8)]
+
+    assert clustergram.plot_data_pca.empty
+    ax = clustergram.plot(pca_kwargs=dict(random_state=random_state))
     ax.get_geometry() == (1, 1, 1)
 
-    clustergram = Clustergram(
-        range(1, 10), backend="sklearn", method="minibatchkmeans", pca_weighted=False
-    )
-    clustergram.fit(device_data)
-
-    pd.testing.assert_series_equal(
-        clustergram.means.mean(),
-        pd.Series(
-            [
-                2.05533664,
-                2.05533664,
-                2.05533664,
-                2.05533664,
-                2.05533664,
-                2.05522513,
-                2.05582383,
-                2.05585776,
-                2.05591782,
-            ],
-            index=list(range(1, 10)),
-        ),
-        rtol=6,
-    )
-
-    ax = clustergram.plot()
+    assert clustergram.plot_data.empty
+    ax = clustergram.plot(pca_weighted=False)
     ax.get_geometry() == (1, 1, 1)
+
+    assert clustergram.plot_data_pca.mean().mean() == -0.19729006113986378
+    assert clustergram.plot_data.mean().mean() == 2.3478208185941405
 
 
 def test_sklearn_gmm():
-    clustergram = Clustergram(range(1, 10), backend="sklearn", method="gmm")
+    clustergram = Clustergram(
+        range(1, 8), backend="sklearn", method="gmm", random_state=random_state
+    )
     clustergram.fit(data)
 
     pd.testing.assert_series_equal(
-        clustergram.means.mean(),
-        pd.Series(
-            [
-                -0.30042205,
-                -0.30042205,
-                -0.30042205,
-                -0.30042205,
-                -0.30042205,
-                -0.30046431,
-                -0.3003699,
-                -0.30086877,
-                -0.30016977,
-            ],
-            index=list(range(1, 10)),
-        ),
-        rtol=6,
+        clustergram.labels.mean(),
+        pd.Series([0.0, 0.2, 0.6, 1.8, 2.0, 2.2, 2.7], index=range(1, 8)),
     )
+    assert clustergram.labels.shape == (10, 7)
+    assert clustergram.labels.notna().all().all()
 
-    ax = clustergram.plot()
+    expected = [
+        2.6841643400794335,
+        2.4203136552626865,
+        2.52976769800815,
+        2.74946247582996,
+        2.333257525098582,
+        2.0444680314214723,
+        2.2697082687156915,
+    ]
+    assert expected == [np.mean(clustergram.cluster_centers[x]) for x in range(1, 8)]
+
+    assert clustergram.plot_data_pca.empty
+    ax = clustergram.plot(pca_kwargs=dict(random_state=random_state))
     ax.get_geometry() == (1, 1, 1)
 
-    clustergram = Clustergram(
-        range(1, 10), backend="sklearn", method="gmm", pca_weighted=False
-    )
-    clustergram.fit(device_data)
-
-    pd.testing.assert_series_equal(
-        clustergram.means.mean(),
-        pd.Series(
-            [
-                2.05533664,
-                2.05533664,
-                2.05533664,
-                2.05533664,
-                2.05533664,
-                2.05522513,
-                2.05582383,
-                2.05585776,
-                2.05591782,
-            ],
-            index=list(range(1, 10)),
-        ),
-        rtol=6,
-    )
-
-    ax = clustergram.plot()
+    assert clustergram.plot_data.empty
+    ax = clustergram.plot(pca_weighted=False)
     ax.get_geometry() == (1, 1, 1)
+
+    assert clustergram.plot_data_pca.mean().mean() == -0.5578663671008622
+    assert clustergram.plot_data.mean().mean() == 2.300054613897816
 
 
 @pytest.mark.skipif(
-    not RAPIDS,
-    reason="RAPIDS not available.",
+    not RAPIDS, reason="RAPIDS not available.",
 )
 def test_cuml_kmeans():
-    n_samples = 1000
+    n_samples = 10
     n_features = 2
 
     n_clusters = 5
@@ -210,106 +160,73 @@ def test_cuml_kmeans():
 
     data = cudf.DataFrame(device_data)
 
-    clustergram = Clustergram(range(1, 10), backend="cuML")
+    # cudf.DataFrame
+    clustergram = Clustergram(range(1, 10), backend="cuML", random_state=random_state)
     clustergram.fit(data)
 
     pd.testing.assert_series_equal(
-        clustergram.means.mean().to_pandas(),
-        pd.Series(
-            [
-                0.30042205,
-                0.30042205,
-                0.30042205,
-                0.30042205,
-                0.30042205,
-                0.30046431,
-                0.3003699,
-                0.30086877,
-                0.30016977,
-            ],
-            index=list(range(1, 10)),
-        ),
-        rtol=6,
+        clustergram.labels.mean().to_pandas(),
+        pd.Series([0.0, 0.2, 0.6, 1.8, 2.0, 2.2, 2.7], index=range(1, 8)),
     )
+    assert clustergram.labels.shape == (10, 7)
+    assert clustergram.labels.notna().all().all()
 
+    expected = [
+        2.3448529748438847,
+        2.793993337861089,
+        2.8270525934022026,
+        2.513999519667852,
+        2.344852974843884,
+        2.059790669470653,
+        2.271614946625764,
+    ]
+    assert expected == [cp.mean(clustergram.cluster_centers[x]) for x in range(1, 8)]
+
+    assert clustergram.plot_data_pca.empty
+    ax = clustergram.plot(pca_kwargs=dict(random_state=random_state))
+    ax.get_geometry() == (1, 1, 1)
+
+    assert clustergram.plot_data.empty
+    ax = clustergram.plot(pca_weighted=False)
+    ax.get_geometry() == (1, 1, 1)
+
+    assert clustergram.plot_data_pca.mean().mean() == -0.21726383145643727
+    assert clustergram.plot_data.mean().mean() == 2.3448529748438847
+
+    # cupy array
     data = device_data
 
     clustergram = Clustergram(range(1, 10), backend="cuML")
     clustergram.fit(data)
 
     pd.testing.assert_series_equal(
-        clustergram.means.mean().to_pandas(),
-        pd.Series(
-            [
-                0.30042205,
-                0.30042205,
-                0.30042205,
-                0.30042205,
-                0.30042205,
-                0.30046431,
-                0.3003699,
-                0.30086877,
-                0.30016977,
-            ],
-            index=list(range(1, 10)),
-        ),
-        rtol=6,
+        clustergram.labels.mean().to_pandas(),
+        pd.Series([0.0, 0.2, 0.6, 1.8, 2.0, 2.2, 2.7], index=range(1, 8)),
     )
+    assert clustergram.labels.shape == (10, 7)
+    assert clustergram.labels.notna().all().all()
 
-    device_data, device_labels = make_blobs(
-        n_samples=n_samples,
-        n_features=n_features,
-        centers=n_clusters,
-        random_state=random_state,
-        cluster_std=0.1,
-    )
+    expected = [
+        2.3448529748438847,
+        2.793993337861089,
+        2.8270525934022026,
+        2.513999519667852,
+        2.344852974843884,
+        2.059790669470653,
+        2.271614946625764,
+    ]
+    assert expected == [cp.mean(clustergram.cluster_centers[x]) for x in range(1, 8)]
 
-    clustergram = Clustergram(range(1, 10), backend="cuML", pca_weighted=False)
-    clustergram.fit(data)
-
-    pd.testing.assert_series_equal(
-        clustergram.means.mean().to_pandas(),
-        pd.Series(
-            [
-                2.31314663,
-                2.31314663,
-                2.31314663,
-                2.31314663,
-                2.31314663,
-                2.31353356,
-                2.31314663,
-                2.31326447,
-                2.31284071,
-            ],
-            index=list(range(1, 10)),
-        ),
-        rtol=6,
-    )
-
-    clustergram = Clustergram(range(1, 10), backend="cuML", pca_weighted=False)
-    clustergram.fit(cudf.DataFrame(device_data))
-
-    pd.testing.assert_series_equal(
-        clustergram.means.mean().to_pandas(),
-        pd.Series(
-            [
-                2.31314663,
-                2.31314663,
-                2.31314663,
-                2.31314663,
-                2.31314663,
-                2.31353356,
-                2.31314663,
-                2.31326447,
-                2.31284071,
-            ],
-            index=list(range(1, 10)),
-        ),
-        rtol=6,
-    )
-
-    ax = clustergram.plot()
+    assert clustergram.plot_data_pca.empty
+    ax = clustergram.plot(pca_kwargs=dict(random_state=random_state))
     ax.get_geometry() == (1, 1, 1)
+
+    assert clustergram.plot_data.empty
+    ax = clustergram.plot(pca_weighted=False)
+    ax.get_geometry() == (1, 1, 1)
+
+    assert clustergram.plot_data_pca.mean().mean() == -0.21726383145643727
+    assert clustergram.plot_data.mean().mean() == 2.3448529748438847
 
 
 def test_errors():
@@ -322,7 +239,90 @@ def test_errors():
 def test_repr_():
     expected = (
         "Clustergram(k_range=range(1, 30), backend='sklearn', "
-        "method='kmeans', pca_weighted=True, kwargs={'n_init': 10})"
+        "method='kmeans', kwargs={'n_init': 10})"
     )
     clustergram = Clustergram(range(1, 30), n_init=10)
     assert expected == clustergram.__repr__()
+
+
+def test_silhouette_score():
+    clustergram = Clustergram(range(1, 8), backend="sklearn", random_state=random_state)
+    clustergram.fit(data)
+
+    pd.testing.assert_series_equal(
+        clustergram.silhouette_score(),
+        pd.Series(
+            [0.70244987, 0.64427202, 0.76772759, 0.94899084, 0.76998519, 0.57564372],
+            index=list(range(2, 8)),
+            name="silhouette_score",
+        ),
+    )
+
+    pd.testing.assert_series_equal(
+        clustergram.silhouette,
+        pd.Series(
+            [0.70244987, 0.64427202, 0.76772759, 0.94899084, 0.76998519, 0.57564372],
+            index=list(range(2, 8)),
+            name="silhouette_score",
+        ),
+    )
+
+
+def test_calinski_harabasz_score():
+    clustergram = Clustergram(range(1, 8), backend="sklearn", random_state=random_state)
+    clustergram.fit(data)
+
+    pd.testing.assert_series_equal(
+        clustergram.calinski_harabasz_score(),
+        pd.Series(
+            [
+                23.17662874,
+                30.64301789,
+                55.22333618,
+                3116.43518408,
+                3899.06868932,
+                4439.30604863,
+            ],
+            index=list(range(2, 8)),
+            name="calinski_harabasz_score",
+        ),
+    )
+
+    pd.testing.assert_series_equal(
+        clustergram.calinski_harabasz,
+        pd.Series(
+            [
+                23.17662874,
+                30.64301789,
+                55.22333618,
+                3116.43518408,
+                3899.06868932,
+                4439.30604863,
+            ],
+            index=list(range(2, 8)),
+            name="calinski_harabasz_score",
+        ),
+    )
+
+
+def test_davies_bouldin_score():
+    clustergram = Clustergram(range(1, 8), backend="sklearn", random_state=random_state)
+    clustergram.fit(data)
+
+    pd.testing.assert_series_equal(
+        clustergram.davies_bouldin_score(),
+        pd.Series(
+            [0.2493657, 0.35181197, 0.34758021, 0.05567944, 0.03051626, 0.02520726],
+            index=list(range(2, 8)),
+            name="davies_bouldin_score",
+        ),
+    )
+
+    pd.testing.assert_series_equal(
+        clustergram.davies_bouldin,
+        pd.Series(
+            [0.2493657, 0.35181197, 0.34758021, 0.05567944, 0.03051626, 0.02520726],
+            index=list(range(2, 8)),
+            name="davies_bouldin_score",
+        ),
+    )

--- a/clustergram/test_clustergram.py
+++ b/clustergram/test_clustergram.py
@@ -49,7 +49,10 @@ def test_sklearn_kmeans():
         2.059790669470653,
         2.271614946625764,
     ]
-    assert expected == [np.mean(clustergram.cluster_centers[x]) for x in range(1, 8)]
+    assert expected == [
+        pytest.approx(np.mean(clustergram.cluster_centers[x]), rel=1e-12)
+        for x in range(1, 8)
+    ]
 
     assert clustergram.plot_data_pca.empty
     ax = clustergram.plot(pca_kwargs=dict(random_state=random_state))
@@ -90,7 +93,10 @@ def test_sklearn_minibatchkmeans():
         2.0602593594306526,
         2.2717280475246584,
     ]
-    assert expected == [np.mean(clustergram.cluster_centers[x]) for x in range(1, 8)]
+    assert expected == [
+        pytest.approx(np.mean(clustergram.cluster_centers[x]), rel=1e-12)
+        for x in range(1, 8)
+    ]
 
     assert clustergram.plot_data_pca.empty
     ax = clustergram.plot(pca_kwargs=dict(random_state=random_state))
@@ -128,7 +134,10 @@ def test_sklearn_gmm():
         2.0444680314214723,
         2.2697082687156915,
     ]
-    assert expected == [np.mean(clustergram.cluster_centers[x]) for x in range(1, 8)]
+    assert expected == [
+        pytest.approx(np.mean(clustergram.cluster_centers[x]), rel=1e-12)
+        for x in range(1, 8)
+    ]
 
     assert clustergram.plot_data_pca.empty
     ax = clustergram.plot(pca_kwargs=dict(random_state=random_state))

--- a/clustergram/test_clustergram.py
+++ b/clustergram/test_clustergram.py
@@ -35,10 +35,8 @@ def test_sklearn_kmeans():
     clustergram = Clustergram(range(1, 8), backend="sklearn", random_state=random_state)
     clustergram.fit(data)
 
-    pd.testing.assert_series_equal(
-        clustergram.labels.mean(),
-        pd.Series([0.0, 0.2, 0.6, 1.8, 2.0, 2.2, 2.7], index=range(1, 8)),
-    )
+    for i in range(1, 8):
+        assert clustergram.labels[i].nunique() == i
     assert clustergram.labels.shape == (10, 7)
     assert clustergram.labels.notna().all().all()
 
@@ -78,10 +76,8 @@ def test_sklearn_minibatchkmeans():
     )
     clustergram.fit(data)
 
-    pd.testing.assert_series_equal(
-        clustergram.labels.mean(),
-        pd.Series([0.0, 0.2, 0.6, 1.2, 2.0, 2.1, 2.6], index=range(1, 8)),
-    )
+    for i in range(1, 8):
+        assert clustergram.labels[i].nunique() == i
     assert clustergram.labels.shape == (10, 7)
     assert clustergram.labels.notna().all().all()
 
@@ -118,10 +114,8 @@ def test_sklearn_gmm():
     )
     clustergram.fit(data)
 
-    pd.testing.assert_series_equal(
-        clustergram.labels.mean(),
-        pd.Series([0.0, 0.2, 0.6, 1.8, 2.0, 2.2, 2.7], index=range(1, 8)),
-    )
+    for i in range(1, 8):
+        assert clustergram.labels[i].nunique() == i
     assert clustergram.labels.shape == (10, 7)
     assert clustergram.labels.notna().all().all()
 
@@ -176,10 +170,8 @@ def test_cuml_kmeans():
     clustergram = Clustergram(range(1, 8), backend="cuML", random_state=random_state)
     clustergram.fit(data)
 
-    pd.testing.assert_series_equal(
-        clustergram.labels.mean().to_pandas(),
-        pd.Series([0, 0.7, 0.9, 1.8, 2, 1.6, 2.2], index=range(1, 8)),
-    )
+    for i in range(1, 8):
+        assert clustergram.labels[i].nunique() == i
     assert clustergram.labels.shape == (10, 7)
     assert clustergram.labels.notna().all().all()
 
@@ -218,10 +210,8 @@ def test_cuml_kmeans():
     clustergram = Clustergram(range(1, 8), backend="cuML", random_state=random_state)
     clustergram.fit(data)
 
-    pd.testing.assert_series_equal(
-        clustergram.labels.mean().to_pandas(),
-        pd.Series([0, 0.7, 0.9, 1.8, 2, 1.6, 2.2], index=range(1, 8)),
-    )
+    for i in range(1, 8):
+        assert clustergram.labels[i].nunique() == i
     assert clustergram.labels.shape == (10, 7)
     assert clustergram.labels.notna().all().all()
 
@@ -320,7 +310,14 @@ def test_silhouette_score_cuml():
     pd.testing.assert_series_equal(
         clustergram.silhouette_score(),
         pd.Series(
-            [0.7494349479675293, 0.9806153178215027, 0.6721830368041992, 0.39418715238571167, 0.44574037194252014, 0.08033210784196854],
+            [
+                0.7494349479675293,
+                0.9806153178215027,
+                0.6721830368041992,
+                0.39418715238571167,
+                0.44574037194252014,
+                0.08033210784196854,
+            ],
             index=list(range(2, 8)),
             name="silhouette_score",
         ),
@@ -332,7 +329,14 @@ def test_silhouette_score_cuml():
     pd.testing.assert_series_equal(
         clustergram.silhouette_score(),
         pd.Series(
-            [0.7494349479675293, 0.9806153178215027, 0.6721830368041992, 0.39418715238571167, 0.44574037194252014, 0.08033210784196854],
+            [
+                0.7494349479675293,
+                0.9806153178215027,
+                0.6721830368041992,
+                0.39418715238571167,
+                0.44574037194252014,
+                0.08033210784196854,
+            ],
             index=list(range(2, 8)),
             name="silhouette_score",
         ),
@@ -402,7 +406,14 @@ def test_calinski_harabasz_score_cuml():
     pd.testing.assert_series_equal(
         clustergram.calinski_harabasz_score(),
         pd.Series(
-            [25.619150510634366, 15374.042816067375, 10813.16845006968, 8818.1163716754, 8070.657293970755, 7259.89764652579],
+            [
+                25.619150510634366,
+                15374.042816067375,
+                10813.16845006968,
+                8818.1163716754,
+                8070.657293970755,
+                7259.89764652579,
+            ],
             index=list(range(2, 8)),
             name="calinski_harabasz_score",
         ),
@@ -414,7 +425,14 @@ def test_calinski_harabasz_score_cuml():
     pd.testing.assert_series_equal(
         clustergram.calinski_harabasz_score(),
         pd.Series(
-            [25.619150510634366, 15374.042816067375, 10813.16845006968, 8818.1163716754, 8070.657293970755, 7259.89764652579],
+            [
+                25.619150510634366,
+                15374.042816067375,
+                10813.16845006968,
+                8818.1163716754,
+                8070.657293970755,
+                7259.89764652579,
+            ],
             index=list(range(2, 8)),
             name="calinski_harabasz_score",
         ),
@@ -470,7 +488,14 @@ def test_davies_bouldin_score_cuml():
     pd.testing.assert_series_equal(
         clustergram.davies_bouldin_score(),
         pd.Series(
-            [0.3107512701086121, 0.02263161666570639, 0.2261582258142144, 0.3839688146565784, 0.13388392354928222, 0.279734367840293],
+            [
+                0.3107512701086121,
+                0.02263161666570639,
+                0.2261582258142144,
+                0.3839688146565784,
+                0.13388392354928222,
+                0.279734367840293,
+            ],
             index=list(range(2, 8)),
             name="davies_bouldin_score",
         ),
@@ -482,7 +507,14 @@ def test_davies_bouldin_score_cuml():
     pd.testing.assert_series_equal(
         clustergram.davies_bouldin_score(),
         pd.Series(
-            [0.3107512701086121, 0.02263161666570639, 0.2261582258142144, 0.3839688146565784, 0.13388392354928222, 0.279734367840293],
+            [
+                0.3107512701086121,
+                0.02263161666570639,
+                0.2261582258142144,
+                0.3839688146565784,
+                0.13388392354928222,
+                0.279734367840293,
+            ],
             index=list(range(2, 8)),
             name="davies_bouldin_score",
         ),

--- a/clustergram/test_clustergram.py
+++ b/clustergram/test_clustergram.py
@@ -127,7 +127,7 @@ def test_sklearn_gmm():
 
     expected = [
         2.6841643400794335,
-        2.4203136552626865,
+        3.1705471246923214,
         2.52976769800815,
         2.74946247582996,
         2.333257525098582,
@@ -148,10 +148,10 @@ def test_sklearn_gmm():
     ax.get_geometry() == (1, 1, 1)
 
     assert clustergram.plot_data_pca.mean().mean() == pytest.approx(
-        -0.5578663671008622, rel=1e-15
+        -0.5099395641282745, rel=1e-15
     )
     assert clustergram.plot_data.mean().mean() == pytest.approx(
-        2.300054613897816, rel=1e-15
+        2.4439850629293924, rel=1e-15
     )
 
 

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -10,4 +10,4 @@ clustergram
 .. currentmodule:: clustergram
 
 .. autoclass:: Clustergram
-   :members: fit, plot
+   :members: fit, plot, silhouette_score, calinski_harabasz_score, davies_bouldin_score

--- a/doc/index.md
+++ b/doc/index.md
@@ -124,7 +124,7 @@ cgram.plot()
 Using Mini Batch K-Means, which can provide significant speedup over K-Means:
 
 ```python
-cgram = Clustergram(range(1, 8), method='minibatchkmeans')
+cgram = Clustergram(range(1, 8), method='minibatchkmeans', batch_size=100)
 cgram.fit(data)
 cgram.plot()
 ```


### PR DESCRIPTION
Closes #7 

This refactors internals a bit, which in turn allows exposing the actual clustering labels for each tested iteration.

Aso adding a few additional methods to assess clustering performance on top of clustergram.