### PR TITLE
ENH: from_data and from_centers methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Clustergram is a diagram proposed by Matthias Schonlau in his paper *[The cluste
 
 The clustergram was later implemented in R by [Tal Galili](https://www.r-statistics.com/2010/06/clustergram-visualization-and-diagnostics-for-cluster-analysis-r-code/), who also gives a thorough explanation of the concept.
 
-This is a Python translation of Tal's script written for `scikit-learn` and RAPIDS `cuML` implementations of K-Means, Mini Batch K-Means and Gaussian Mixture Model (scikit-learn only) clustering, plus hierarchical/agglomerative clustering using `SciPy`.
+This is a Python translation of Tal's script written for `scikit-learn` and RAPIDS `cuML` implementations of K-Means, Mini Batch K-Means and Gaussian Mixture Model (scikit-learn only) clustering, plus hierarchical/agglomerative clustering using `SciPy`. Alternatively, you can create clustergram using  `from_*` constructors based on alternative clustering algorithms.
 
 ## Getting started
 
@@ -144,6 +144,40 @@ Using Ward's hierarchical clustering:
 ```python
 cgram = Clustergram(range(1, 8), method='hierarchical', linkage='ward')
 cgram.fit(data)
+cgram.plot()
+```
+
+## Manual input
+
+Alternatively, you can create clustergram using `from_data` or  `from_centers` methods based on alternative clustering algorithms.
+
+Using `Clustergram.from_data` which creates cluster centers as mean or median values:
+
+```python
+data = numpy.array([[-1, -1, 0, 10], [1, 1, 10, 2], [0, 0, 20, 4]])
+labels = pandas.DataFrame({1: [0, 0, 0], 2: [0, 0, 1], 3: [0, 2, 1]})
+
+cgram = Clustergram.from_data(data, labels)
+cgram.plot()
+```
+
+Using `Clustergram.from_centers` based on explicit cluster centers.:
+
+```python
+labels = pandas.DataFrame({1: [0, 0, 0], 2: [0, 0, 1], 3: [0, 2, 1]})
+centers = {
+            1: np.array([[0, 0]]),
+            2: np.array([[-1, -1], [1, 1]]),
+            3: np.array([[-1, -1], [1, 1], [0, 0]]),
+        }
+cgram = Clustergram.from_centers(centers, labels)
+cgram.plot(pca_weighted=False)
+```
+
+To support PCA weighted plots you also need to pass data:
+
+```python
+cgram = Clustergram.from_centers(centers, labels, data=data)
 cgram.plot()
 ```
 

--- a/clustergram/clustergram.py
+++ b/clustergram/clustergram.py
@@ -13,7 +13,6 @@ Original idea is by Matthias Schonlau - http://www.schonlau.net/clustergram.html
 from time import time
 import pandas as pd
 import numpy as np
-import sklearn
 
 
 class Clustergram:
@@ -30,6 +29,9 @@ class Clustergram:
     ``scipy`` which use CPU and RAPIDS.AI ``cuML``, which uses GPU. Note that all
     are optional dependencies but you will need at least one of them to
     generate clustergram.
+
+    Alternatively, you can create clustergram using ``from_data`` or
+    ``from_centers`` methods based on alternative clustering algorithms.
 
     Parameters
     ----------

--- a/clustergram/clustergram.py
+++ b/clustergram/clustergram.py
@@ -444,7 +444,9 @@ class Clustergram:
             elif method == "median":
                 cgram.cluster_centers[i] = data.groupby(labels[i]).median().values
             else:
-                raise ValueError(f"{method} is not supported. Use 'mean' or 'median'.")
+                raise ValueError(
+                    f"'{method}' is not supported. Use 'mean' or 'median'."
+                )
 
         cgram.labels = labels
         cgram.backend = "sklearn"

--- a/clustergram/clustergram.py
+++ b/clustergram/clustergram.py
@@ -64,8 +64,7 @@ class Clustergram:
         Additional arguments passed to the model (e.g. ``KMeans``),
         e.g. ``random_state``. Pass ``linkage`` to specify linkage method in
         case of hierarchical clustering (e.g. ``linkage='ward'``). See the
-        documentation of scipy for details:
-        https://docs.scipy.org/doc/scipy/reference/generated/scipy.cluster.hierarchy.linkage.html#scipy.cluster.hierarchy.linkage
+        documentation of scipy for details.
 
 
     Attributes
@@ -471,7 +470,7 @@ class Clustergram:
 
         Returns
         -------
-        self.silhouette : pd.Series
+        silhouette : pd.Series
 
         Notes
         -----
@@ -540,7 +539,7 @@ class Clustergram:
 
         Returns
         -------
-        self.calinski_harabasz : pd.Series
+        calinski_harabasz : pd.Series
 
         Notes
         -----
@@ -608,7 +607,7 @@ class Clustergram:
 
         Returns
         -------
-        self.davies_bouldin : pd.Series
+        davies_bouldin : pd.Series
 
         Notes
         -----

--- a/clustergram/clustergram.py
+++ b/clustergram/clustergram.py
@@ -13,6 +13,7 @@ Original idea is by Matthias Schonlau - http://www.schonlau.net/clustergram.html
 from time import time
 import pandas as pd
 import numpy as np
+import sklearn
 
 
 class Clustergram:
@@ -130,7 +131,8 @@ class Clustergram:
             self.backend = backend
 
         supported = ["kmeans", "gmm", "minibatchkmeans", "hierarchical"]
-        if method not in supported:
+        class_methods = ["from_centers", "from_data"]
+        if method not in supported and method not in class_methods:
             raise ValueError(
                 f"'{method}' is not a supported method. "
                 f"Only {supported} are supported now."
@@ -313,6 +315,141 @@ class Clustergram:
             lab = hierarchy.fcluster(self.linkage, d, criterion="distance")
             self.labels[i] = lab - 1
             self.cluster_centers[i] = data.groupby(lab).mean().values
+
+    @classmethod
+    def from_centers(cls, cluster_centers, labels, data=None):
+        """Create clustergram based on cluster centers dictionary and labels DataFrame
+
+        Parameters
+        ----------
+
+        cluster_centers : dict
+            dictionary of cluster centers with keys encoding the number of clusters
+            and values being ``M``x````N`` arrays where ``M`` == key and ``N`` ==
+            number of variables in the original dataset.
+            Entries should be ordered based on keys.
+        labels : pandas.DataFrame
+            DataFrame with columns representing cluster labels and rows representing
+            observations. Columns must be equal to ``cluster_centers`` keys.
+        data : array-like (optional)
+            array used as an input of the clustering algorithm with ``N`` columns.
+            Required for `plot(pca_weighted=True)` plotting option. Otherwise only
+            `plot(pca_weighted=False)` is available.
+
+        Returns
+        -------
+        clustegram.Clustergram
+
+        Notes
+        -----
+        The algortihm uses ``sklearn`` and ``pandas`` to generate clustergram.
+        GPU option is not implemented.
+
+        Examples
+        --------
+        >>> import pandas as pd
+        >>> import numpy as np
+        >>> labels = pd.DataFrame({1: [0, 0, 0], 2: [0, 0, 1], 3: [0, 2, 1]})
+        >>> labels
+           1  2  3
+        0  0  0  0
+        1  0  0  2
+        2  0  1  1
+        >>> centers = {
+        ...             1: np.array([[0, 0]]),
+        ...             2: np.array([[-1, -1], [1, 1]]),
+        ...             3: np.array([[-1, -1], [1, 1], [0, 0]]),
+        ...         }
+        >>> cgram = Clustergram.from_centers(centers, labels)
+        >>> cgram.plot(pca_weighted=False)
+
+        >>> data = np.array([[-1, -1], [1, 1], [0, 0]])
+        >>> cgram = Clustergram.from_centers(centers, labels, data=data)
+        >>> cgram.plot()
+
+        """
+        if not (list(cluster_centers.keys()) == labels.columns).all():
+            raise ValueError("'cluster_centers' keys do not match 'labels' columns.")
+
+        cgram = cls(k_range=list(cluster_centers.keys()), method="from_centers")
+
+        cgram.cluster_centers = cluster_centers
+        cgram.labels = labels
+        cgram.backend = "sklearn"
+
+        if data is not None:
+            cgram.data = data
+
+        return cgram
+
+    @classmethod
+    def from_data(cls, data, labels, method="mean"):
+        """Create clustergram based on data and labels DataFrame
+
+        Cluster centers are created as mean values or median values as a
+        groupby function over data using individual labels.
+
+        Parameters
+        ----------
+
+        data : array-like
+            array used as an input of the clustering algorithm in the ``(M, N)`` shape
+            where ``M`` == number of observations and ``N`` == number of variables
+        labels : pandas.DataFrame
+            DataFrame with columns representing cluster labels and rows representing
+            observations. Columns must be equal to ``cluster_centers`` keys.
+        method : {'mean', 'median'}, default 'mean'
+            Method of computation of cluster centres.
+
+        Returns
+        -------
+        clustegram.Clustergram
+
+        Notes
+        -----
+        The algortihm uses ``sklearn`` and ``pandas`` to generate clustergram.
+        GPU option is not implemented.
+
+        Examples
+        --------
+        >>> import pandas as pd
+        >>> import numpy as np
+        >>> data = np.array([[-1, -1, 0, 10], [1, 1, 10, 2], [0, 0, 20, 4]])
+        >>> data
+        array([[-1, -1,  0, 10],
+               [ 1,  1, 10,  2],
+               [ 0,  0, 20,  4]])
+        >>> labels = pd.DataFrame({1: [0, 0, 0], 2: [0, 0, 1], 3: [0, 2, 1]})
+        >>> labels
+           1  2  3
+        0  0  0  0
+        1  0  0  2
+        2  0  1  1
+        >>> cgram = Clustergram.from_data(data, labels)
+        >>> cgram.plot()
+
+        """
+
+        cgram = cls(k_range=list(labels.columns), method="from_data")
+
+        cgram.cluster_centers = {}
+        cgram.data = data
+
+        if not isinstance(data, pd.DataFrame):
+            data = pd.DataFrame(data)
+
+        for i in cgram.k_range:
+            if method == "mean":
+                cgram.cluster_centers[i] = data.groupby(labels[i]).mean().values
+            elif method == "median":
+                cgram.cluster_centers[i] = data.groupby(labels[i]).median().values
+            else:
+                raise ValueError(f"{method} is not supported. Use 'mean' or 'median'.")
+
+        cgram.labels = labels
+        cgram.backend = "sklearn"
+
+        return cgram
 
     def silhouette_score(self, **kwargs):
         """

--- a/clustergram/test_clustergram.py
+++ b/clustergram/test_clustergram.py
@@ -589,3 +589,98 @@ def test_davies_bouldin_score_cuml():
             name="davies_bouldin_score",
         ),
     )
+
+
+def test_from_data_mean():
+    data = np.array([[-1, -1, 0, 10], [1, 1, 10, 2], [0, 0, 20, 4]])
+    labels = pd.DataFrame({1: [0, 0, 0], 2: [0, 0, 1], 3: [0, 2, 1]})
+    clustergram = Clustergram.from_data(data, labels)
+
+    assert clustergram.plot_data_pca.empty
+    ax = clustergram.plot(pca_kwargs=dict(random_state=random_state))
+    ax.get_geometry() == (1, 1, 1)
+
+    assert clustergram.plot_data.empty
+    ax = clustergram.plot(pca_weighted=False)
+    ax.get_geometry() == (1, 1, 1)
+
+    assert clustergram.plot_data_pca.mean().mean() == pytest.approx(
+        -7.820673888000655, rel=1e-15
+    )
+    assert clustergram.plot_data.mean().mean() == pytest.approx(
+        3.8333333333333335, rel=1e-15
+    )
+
+
+def test_from_data_median():
+    data = np.array([[-1, -1, 0, 10], [1, 1, 10, 2], [0, 0, 20, 4]])
+    labels = pd.DataFrame({1: [0, 0, 0], 2: [0, 0, 1], 3: [0, 2, 1]})
+    clustergram = Clustergram.from_data(data, labels, method="median")
+
+    assert clustergram.plot_data_pca.empty
+    ax = clustergram.plot(pca_kwargs=dict(random_state=random_state))
+    ax.get_geometry() == (1, 1, 1)
+
+    assert clustergram.plot_data.empty
+    ax = clustergram.plot(pca_weighted=False)
+    ax.get_geometry() == (1, 1, 1)
+
+    assert clustergram.plot_data_pca.mean().mean() == pytest.approx(
+        -7.958519683972767, rel=1e-15
+    )
+    assert clustergram.plot_data.mean().mean() == pytest.approx(
+        3.7222222222222228, rel=1e-15
+    )
+
+
+def test_from_data_nonsense():
+    data = np.array([[-1, -1, 0, 10], [1, 1, 10, 2], [0, 0, 20, 4]])
+    labels = pd.DataFrame({1: [0, 0, 0], 2: [0, 0, 1], 3: [0, 2, 1]})
+    with pytest.raises(ValueError, match="'nonsense' is not supported."):
+        Clustergram.from_data(data, labels, method="nonsense")
+
+
+def test_from_centers():
+    labels = pd.DataFrame({1: [0, 0, 0], 2: [0, 0, 1], 3: [0, 2, 1]})
+    centers = {
+        1: np.array([[0, 0]]),
+        2: np.array([[-1, -1], [1, 1]]),
+        3: np.array([[-1, -1], [1, 1], [0, 0]]),
+    }
+    clustergram = Clustergram.from_centers(centers, labels)
+
+    assert clustergram.plot_data.empty
+    ax = clustergram.plot(pca_weighted=False)
+    ax.get_geometry() == (1, 1, 1)
+
+    assert clustergram.plot_data.mean().mean() == pytest.approx(
+        -0.1111111111111111, rel=1e-15
+    )
+
+    labels = pd.DataFrame({2: [0, 0, 0], 3: [0, 0, 1], 4: [0, 2, 1]})
+    centers = {
+        1: np.array([[0, 0]]),
+        2: np.array([[-1, -1], [1, 1]]),
+        3: np.array([[-1, -1], [1, 1], [0, 0]]),
+    }
+    with pytest.raises(ValueError, match="'cluster_centers' keys do not match"):
+        Clustergram.from_centers(centers, labels)
+
+
+def test_from_centers_data():
+    labels = pd.DataFrame({1: [0, 0, 0], 2: [0, 0, 1], 3: [0, 2, 1]})
+    centers = {
+        1: np.array([[0, 0]]),
+        2: np.array([[-1, -1], [1, 1]]),
+        3: np.array([[-1, -1], [1, 1], [0, 0]]),
+    }
+    data = np.array([[-1, -1], [1, 1], [0, 0]])
+    clustergram = Clustergram.from_centers(centers, labels, data)
+
+    assert clustergram.plot_data_pca.empty
+    ax = clustergram.plot(pca_weighted=True)
+    ax.get_geometry() == (1, 1, 1)
+
+    assert clustergram.plot_data_pca.mean().mean() == pytest.approx(
+        -0.15713484026367722, rel=1e-15
+    )

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -10,4 +10,4 @@ clustergram
 .. currentmodule:: clustergram
 
 .. autoclass:: Clustergram
-   :members: fit, plot, silhouette_score, calinski_harabasz_score, davies_bouldin_score
+   :members: fit, plot, from_data, from_centers, silhouette_score, calinski_harabasz_score, davies_bouldin_score

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -34,6 +34,7 @@ release = version
 extensions = ["sphinx.ext.autodoc", "numpydoc", "sphinx.ext.autosummary", "myst_parser"]
 
 autosummary_generate = True
+numpydoc_show_class_members = True
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]

--- a/doc/index.md
+++ b/doc/index.md
@@ -8,7 +8,8 @@ Clustergram is a diagram proposed by Matthias Schonlau in his paper *[The cluste
 
 The clustergram was later implemented in R by [Tal Galili](https://www.r-statistics.com/2010/06/clustergram-visualization-and-diagnostics-for-cluster-analysis-r-code/), who also gives a thorough explanation of the concept.
 
-This is a Python translation of Tal's script written for `scikit-learn` and RAPIDS `cuML` implementations of K-Means, Mini Batch K-Means and Gaussian Mixture Model (scikit-learn only) clustering, plus hierarchical/agglomerative clustering using `SciPy`.
+This is a Python translation of Tal's script written for `scikit-learn` and RAPIDS `cuML` implementations of K-Means, Mini Batch K-Means and Gaussian Mixture Model (scikit-learn only) clustering, plus hierarchical/agglomerative clustering using `SciPy`. Alternatively, you can create clustergram using  `from_*` constructors based on alternative clustering algorithms.
+
 
 ## Getting started
 
@@ -142,6 +143,40 @@ Using Ward's hierarchical clustering:
 ```python
 cgram = Clustergram(range(1, 8), method='hierarchical', linkage='ward')
 cgram.fit(data)
+cgram.plot()
+```
+
+## Manual input
+
+Alternatively, you can create clustergram using `from_data` or  `from_centers` methods based on alternative clustering algorithms.
+
+Using `Clustergram.from_data` which creates cluster centers as mean or median values:
+
+```python
+data = numpy.array([[-1, -1, 0, 10], [1, 1, 10, 2], [0, 0, 20, 4]])
+labels = pandas.DataFrame({1: [0, 0, 0], 2: [0, 0, 1], 3: [0, 2, 1]})
+
+cgram = Clustergram.from_data(data, labels)
+cgram.plot()
+```
+
+Using `Clustergram.from_centers` based on explicit cluster centers.:
+
+```python
+labels = pandas.DataFrame({1: [0, 0, 0], 2: [0, 0, 1], 3: [0, 2, 1]})
+centers = {
+            1: np.array([[0, 0]]),
+            2: np.array([[-1, -1], [1, 1]]),
+            3: np.array([[-1, -1], [1, 1], [0, 0]]),
+        }
+cgram = Clustergram.from_centers(centers, labels)
+cgram.plot(pca_weighted=False)
+```
+
+To support PCA weighted plots you also need to pass data:
+
+```python
+cgram = Clustergram.from_centers(centers, labels, data=data)
 cgram.plot()
 ```
 


### PR DESCRIPTION
Addind the ability to create clustergram using custom data, without the need to run any cluster algorithm within clustergram itself.

`from_data` gets labels and data and creates cluster centers as mean or median values.

`from_centers` utilises custom centers when mean/median is not the optimal solution (like in case of GMM for example).

Closes #10