### PR TITLE
ENH: support interactive bokeh plots

### DIFF
--- a/ci/envs/latest.yaml
+++ b/ci/envs/latest.yaml
@@ -10,3 +10,4 @@ dependencies:
   - pandas
   - numpy
   - matplotlib
+  - bokeh

--- a/clustergram/clustergram.py
+++ b/clustergram/clustergram.py
@@ -670,16 +670,21 @@ class Clustergram:
         from sklearn.decomposition import PCA
 
         self.pca = PCA(n_components=1, **pca_kwargs).fit(self.data).components_[0]
+        self.link_pca = {}
 
         for n in self.k_range:
             means = self.cluster_centers[n].dot(self.pca)
             self.plot_data_pca[n] = np.take(means, self.labels[n].values)
+            self.link_pca[n] = dict(zip(means, range(n)))
 
     def _compute_means_sklearn(self):
         """Compute cluster mean values using sklearn backend"""
+        self.link = {}
+
         for n in self.k_range:
             means = np.mean(self.cluster_centers[n], axis=1)
             self.plot_data[n] = np.take(means, self.labels[n].values)
+            self.link[n] = dict(zip(means, range(n)))
 
     def _compute_pca_means_cuml(self, **pca_kwargs):
         """Compute PCA weighted cluster mean values using cuML backend"""
@@ -688,6 +693,7 @@ class Clustergram:
         import cupy as cp
 
         self.pca = PCA(n_components=1, **pca_kwargs).fit(self.data)
+        self.link_pca = {}
 
         for n in self.k_range:
             if isinstance(self.data, cudf.DataFrame):
@@ -697,10 +703,12 @@ class Clustergram:
             else:
                 means = self.cluster_centers[n].dot(self.pca.components_[0])
             self.plot_data_pca[n] = cp.take(means, self.labels[n].values)
+            self.link_pca[n] = dict(zip(means, range(n)))
 
     def _compute_means_cuml(self):
         """Compute cluster mean values using cuML backend"""
         import cupy as cp
+        self.link = {}
 
         for n in self.k_range:
             means = self.cluster_centers[n].mean(axis=1)
@@ -708,6 +716,23 @@ class Clustergram:
                 self.plot_data[n] = means.take(self.labels[n].values)
             else:
                 self.plot_data[n] = means.take(self.labels[n].values).to_array()
+            self.link[n] = dict(zip(means, range(n)))
+
+    def _compute_means(self, pca_weighted, pca_kwargs):
+        if pca_weighted:
+            if self.plot_data_pca.empty:
+                pca_kwargs.pop("n_components", None)
+
+                if self.backend in ["sklearn", "scipy"]:
+                    self._compute_pca_means_sklearn(**pca_kwargs)
+                else:
+                    self._compute_pca_means_cuml(**pca_kwargs)
+        else:
+            if self.plot_data.empty:
+                if self.backend in ["sklearn", "scipy"]:
+                    self._compute_means_sklearn()
+                else:
+                    self._compute_means_cuml()
 
     def plot(
         self,
@@ -769,20 +794,7 @@ class Clustergram:
         Those are computed on the first call of each option (pca_weighted=True/False).
 
         """
-        if pca_weighted:
-            if self.plot_data_pca.empty:
-                pca_kwargs.pop("n_components", None)
-
-                if self.backend in ["sklearn", "scipy"]:
-                    self._compute_pca_means_sklearn(**pca_kwargs)
-                else:
-                    self._compute_pca_means_cuml(**pca_kwargs)
-        else:
-            if self.plot_data.empty:
-                if self.backend in ["sklearn", "scipy"]:
-                    self._compute_means_sklearn()
-                else:
-                    self._compute_means_cuml()
+        self._compute_means(pca_weighted, pca_kwargs)
 
         if ax is None:
             import matplotlib.pyplot as plt
@@ -857,3 +869,175 @@ class Clustergram:
             except (KeyError, ValueError):
                 pass
         return ax
+
+    def bokeh(
+        self,
+        fig=None,
+        size=1,
+        line_width=1,
+        cluster_style=None,
+        line_style=None,
+        figsize=None,
+        pca_weighted=True,
+        pca_kwargs={},
+    ):
+        """
+        Generate interactive clustergram plot based on cluster centre mean values using
+        Bokeh.
+
+        Requires ``bokeh``.
+
+        Parameters
+        ----------
+        fig : bokeh.plotting.figure.Figure (default None)
+            bokeh figure on which to draw the plot
+        size : float (default 1)
+            multiplier of the size of a cluster centre indication. Size is determined as
+            ``50 / count`` of observations in a cluster multiplied by ``size``.
+        line_width : float (default 1)
+            multiplier of the linewidth of a branch. Line width is determined as
+            ``50 / count`` of observations in a branch multiplied by `line_width`.
+        cluster_style : dict (default None)
+            Style options to be passed on to the cluster centre plot, such
+            as ``color``, ``line_width``, ``line_color`` or ``alpha``.
+        line_style : dict (default None)
+            Style options to be passed on to branches, such
+            as ``color``, ``line_width``, ``line_color`` or ``alpha``.
+        figsize : tuple of integers (default None)
+            Size of the resulting ``bokeh.plotting.figure.Figure``. If the argument
+            ``figure`` is given explicitly, ``figsize`` is ignored.
+        pca_weighted : bool (default True)
+            Whether use PCA weighted mean of clusters or standard mean of clusters on
+            y-axis.
+        pca_kwargs : dict (default {})
+            Additional arguments passed to the PCA object,
+            e.g. ``svd_solver``. Applies only if ``pca_weighted=True``.
+
+        Returns
+        -------
+        figure : bokeh figure instance
+
+        Examples
+        --------
+        >>> from bokeh.plotting import show
+        >>> c_gram = clustergram.Clustergram(range(1, 9))
+        >>> c_gram.fit(data)
+        >>> f = c_gram.bokeh()
+        >>> show(f)
+
+        For the best experience in Jupyter notebooks, specify bokeh output first:
+
+        >>> from bokeh.io import output_notebook
+        >>> from bokeh.plotting import show
+        >>> output_notebook()
+
+        >>> c_gram = clustergram.Clustergram(range(1, 9))
+        >>> c_gram.fit(data)
+        >>> f = c_gram.bokeh()
+        >>> show(f)
+
+        Notes
+        -----
+        Before plotting, ``Clustergram`` needs to compute the summary values.
+        Those are computed on the first call of each option (pca_weighted=True/False).
+
+        """
+        try:
+            from bokeh.plotting import figure, ColumnDataSource
+            from bokeh.models import HoverTool
+        except ImportError:
+            raise ImportError("'bokeh' is required to use bokeh plotting backend.")
+
+        self._compute_means(pca_weighted, pca_kwargs)
+
+        if pca_weighted:
+            means = self.plot_data_pca
+            links = self.link_pca
+            ylabel = "PCA weighted mean of the clusters"
+        else:
+            means = self.plot_data
+            links = self.link
+            ylabel = "Mean of the clusters"
+
+        if fig is None:
+            if figsize is None:
+                figsize = (600, 500)
+            fig = figure(
+                plot_width=figsize[0],
+                plot_height=figsize[1],
+                x_axis_label="Number of clusters (k)",
+                y_axis_label=ylabel,
+            )
+
+        if cluster_style is None:
+            cluster_style = {}
+        cl_c = cluster_style.pop("color", "red")
+        cl_ec = cluster_style.pop("line_color", "white")
+        cl_lw = cluster_style.pop("line_width", 2)
+
+        if line_style is None:
+            line_style = {}
+        l_c = line_style.pop("color", "black")
+        line_cap = line_style.pop("line_cap", "round")
+
+        x = []
+        y = []
+        sizes = []
+        count = []
+        ratio = []
+        cluster_labels = []
+
+        total = len(means)
+        for i in self.k_range:
+            cl = means[i].value_counts()
+            x += [i] * i
+            y += cl.index.to_list()
+            count += cl.values.tolist()
+            ratio += ((cl / total) * 100).values.tolist()
+            sizes += (cl * ((50 / len(means)) * size)).to_list()
+            cluster_labels += [links[i][x] for x in cl.index]
+
+        source = ColumnDataSource(
+            data=dict(
+                x=x,
+                y=y,
+                size=sizes,
+                count=count,
+                ratio=ratio,
+                cluster_labels=cluster_labels,
+            )
+        )
+
+        tooltips = [
+            ("Number of observations", "@count (@ratio%)"),
+            ("Cluster label", "@cluster_labels"),
+        ]
+
+        stop = max(self.k_range)
+        for i in self.k_range:
+            if i < stop:
+                sub = means.groupby([i, i + 1]).count().reset_index()
+                for r in sub.itertuples():
+                    fig.line(
+                        [i, i + 1],
+                        [r[1], r[2]],
+                        line_width=r[3] * ((50 / len(means)) * line_width),
+                        line_cap=line_cap,
+                        color=l_c,
+                        **line_style,
+                    )
+
+        circle = fig.circle(
+            "x",
+            "y",
+            size="size",
+            source=source,
+            color=cl_c,
+            line_color=cl_ec,
+            line_width=cl_lw,
+            **cluster_style,
+        )
+        hover = HoverTool(tooltips=tooltips, renderers=[circle])
+        fig.add_tools(hover)
+
+        return fig

--- a/clustergram/test_clustergram.py
+++ b/clustergram/test_clustergram.py
@@ -2,6 +2,8 @@ from sklearn.datasets import make_blobs
 import pandas as pd
 import numpy as np
 import pytest
+from bokeh.embed import json_item
+
 
 try:
     import cudf
@@ -684,3 +686,25 @@ def test_from_centers_data():
     assert clustergram.plot_data_pca.mean().mean() == pytest.approx(
         -0.15713484026367722, rel=1e-15
     )
+
+
+def test_bokeh():
+    clustergram = Clustergram(range(1, 8), backend="sklearn", random_state=random_state)
+    clustergram.fit(data)
+
+    f = clustergram.bokeh()
+    out = str(json_item(f, "clustergram"))
+
+    strings = [
+        "'attributes': {'data': {'x': [5, 6], 'y': [-3.111385508584995, -3.2699904570818727]",  # noqa
+        "'data': {'x': [1, 2], 'y': [-0.21726383145643724, -2.438661983909207]",
+        "'cluster_labels': [0, 0, 1, 2, 1, 0, 3, 2, 0,",
+        "'count': [10, 8, 2, 6, 2, 2, 4, 2, 2, 2, 2, 2, 2",
+        "'ratio': [100.0, 80.0, 20.0, 60.0, 20.0, 20.0, 40.0",
+        "'size': [50.0, 40.0, 10.0, 30.0, 10.0, 10.0, 20.0",
+        "'x': [1, 2, 2, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5",
+        "'y': [-0.21726383145643724, -2.438661983909207, 8.668328778354642",
+    ]
+
+    for s in strings:
+        assert s in out

--- a/clustergram/test_clustergram.py
+++ b/clustergram/test_clustergram.py
@@ -137,7 +137,7 @@ def test_sklearn_gmm():
         2.2697082687156915,
     ]
     assert expected == [
-        pytest.approx(np.mean(clustergram.cluster_centers[x]), rel=1e-12)
+        pytest.approx(np.mean(clustergram.cluster_centers[x]), rel=1e-6)
         for x in range(1, 8)
     ]
 
@@ -704,6 +704,65 @@ def test_bokeh():
         "'size': [50.0, 40.0, 10.0, 30.0, 10.0, 10.0, 20.0",
         "'x': [1, 2, 2, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5",
         "'y': [-0.21726383145643724, -2.438661983909207, 8.668328778354642",
+    ]
+
+    for s in strings:
+        assert s in out
+
+    f = clustergram.bokeh(pca_weighted=False)
+    out = str(json_item(f, "clustergram"))
+
+    strings = [
+        "'attributes': {'data': {'x': [5, 6], 'y': [0.6344791426044951, 0.6684377221730675]",  # noqa
+        "'data': {'x': [1, 2], 'y': [2.3448529748438847, 3.5425606095564293]",
+        "'cluster_labels': [0, 0, 1, 2, 0, 1, 3, 1, 0, 2, 1, 0, 4, 2, 3, 1, 0",
+        "'count': [10, 8, 2, 6, 2, 2, 4, 2,",
+        "'ratio': [100.0, 80.0, 20.0, 60.0, 20.0, 20.0",
+        "'size': [50.0, 40.0, 10.0, 30.0, 10.0, 10.0, 20.0, 10.0",
+        "'x': [1, 2, 2, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5, 5,",
+        "'y': [2.3448529748438847, 2.0454260661657484, 3.5425606095564293",
+    ]
+
+    for s in strings:
+        assert s in out
+
+
+@pytest.mark.skipif(
+    not RAPIDS,
+    reason="RAPIDS not available.",
+)
+def test_bokeh_cuml():
+    n_samples = 10
+    n_features = 2
+
+    n_clusters = 5
+    random_state = 0
+
+    device_data, device_labels = cuml.make_blobs(
+        n_samples=n_samples,
+        n_features=n_features,
+        centers=n_clusters,
+        random_state=random_state,
+        cluster_std=0.1,
+    )
+
+    data = cudf.DataFrame(device_data)
+
+    clustergram = Clustergram(range(1, 8), backend="cuML", random_state=random_state)
+    clustergram.fit(data)
+
+    f = clustergram.bokeh()
+    out = str(json_item(f, "clustergram"))
+
+    strings = [
+        "'attributes': {'data': {'x': [4, 5], 'y': [-8.076885223388672, -8.050299644470215]",  # noqa
+        "'data': {'x': [4, 5], 'y': [-0.5628390312194824, -0.5628390312194824]",
+        "'cluster_labels': [0, 1, 0, 0, 2, 1, 2, 3, 1, 0, 3, 1, 2, 4",
+        "'count': [10, 7, 3, 4, 3, 3, 3, 3, 3, 1, 3, 3, 2, 1,",
+        "'ratio': [100.0, 70.0, 30.0, 40.0, 30.0, 30.0, 30.0,",
+        "'size': [50.0, 35.0, 15.0, 20.0, 15.0, 15.0,",
+        "'x': [1, 2, 2, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5",
+        "'y': [1.1016589403152466, -3.7701244354248047, 12.469154357910156",
     ]
 
     for s in strings:

--- a/clustergram/test_clustergram.py
+++ b/clustergram/test_clustergram.py
@@ -692,39 +692,27 @@ def test_bokeh():
     clustergram = Clustergram(range(1, 8), backend="sklearn", random_state=random_state)
     clustergram.fit(data)
 
-    f = clustergram.bokeh()
+    f = clustergram.bokeh(pca_kwargs=dict(random_state=random_state))
     out = str(json_item(f, "clustergram"))
 
-    strings = [
-        "'attributes': {'data': {'x': [5, 6], 'y': [-3.111385508584995, -3.2699904570818727]",  # noqa
-        "'data': {'x': [1, 2], 'y': [-0.21726383145643724, -2.438661983909207]",
-        "'cluster_labels': [0, 0, 1, 2, 1, 0, 3, 2, 0,",
-        "'count': [10, 8, 2, 6, 2, 2, 4, 2, 2, 2, 2, 2, 2",
-        "'ratio': [100.0, 80.0, 20.0, 60.0, 20.0, 20.0, 40.0",
-        "'size': [50.0, 40.0, 10.0, 30.0, 10.0, 10.0, 20.0",
-        "'x': [1, 2, 2, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5",
-        "'y': [-0.21726383145643724, -2.438661983909207, 8.668328778354642",
-    ]
-
-    for s in strings:
-        assert s in out
+    assert out.count("data") == 56
+    assert out.count("'x'") == 140
+    assert out.count("'y'") == 140
+    assert "cluster_labels" in out
+    assert "count" in out
+    assert "ratio" in out
+    assert "size" in out
 
     f = clustergram.bokeh(pca_weighted=False)
     out = str(json_item(f, "clustergram"))
 
-    strings = [
-        "'attributes': {'data': {'x': [5, 6], 'y': [0.6344791426044951, 0.6684377221730675]",  # noqa
-        "'data': {'x': [1, 2], 'y': [2.3448529748438847, 3.5425606095564293]",
-        "'cluster_labels': [0, 0, 1, 2, 0, 1, 3, 1, 0, 2, 1, 0, 4, 2, 3, 1, 0",
-        "'count': [10, 8, 2, 6, 2, 2, 4, 2,",
-        "'ratio': [100.0, 80.0, 20.0, 60.0, 20.0, 20.0",
-        "'size': [50.0, 40.0, 10.0, 30.0, 10.0, 10.0, 20.0, 10.0",
-        "'x': [1, 2, 2, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5, 5,",
-        "'y': [2.3448529748438847, 2.0454260661657484, 3.5425606095564293",
-    ]
-
-    for s in strings:
-        assert s in out
+    assert out.count("data") == 56
+    assert out.count("'x'") == 140
+    assert out.count("'y'") == 140
+    assert "cluster_labels" in out
+    assert "count" in out
+    assert "ratio" in out
+    assert "size" in out
 
 
 @pytest.mark.skipif(
@@ -754,16 +742,10 @@ def test_bokeh_cuml():
     f = clustergram.bokeh()
     out = str(json_item(f, "clustergram"))
 
-    strings = [
-        "'attributes': {'data': {'x': [4, 5], 'y': [-8.076885223388672, -8.050299644470215]",  # noqa
-        "'data': {'x': [4, 5], 'y': [-0.5628390312194824, -0.5628390312194824]",
-        "'cluster_labels': [0, 1, 0, 0, 2, 1, 2, 3, 1, 0, 3, 1, 2, 4",
-        "'count': [10, 7, 3, 4, 3, 3, 3, 3, 3, 1, 3, 3, 2, 1,",
-        "'ratio': [100.0, 70.0, 30.0, 40.0, 30.0, 30.0, 30.0,",
-        "'size': [50.0, 35.0, 15.0, 20.0, 15.0, 15.0,",
-        "'x': [1, 2, 2, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5",
-        "'y': [1.1016589403152466, -3.7701244354248047, 12.469154357910156",
-    ]
-
-    for s in strings:
-        assert s in out
+    assert out.count("data") == 58
+    assert out.count("'x'") == 145
+    assert out.count("'y'") == 145
+    assert "cluster_labels" in out
+    assert "count" in out
+    assert "ratio" in out
+    assert "size" in out

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -10,4 +10,4 @@ clustergram
 .. currentmodule:: clustergram
 
 .. autoclass:: Clustergram
-   :members: fit, plot, from_data, from_centers, silhouette_score, calinski_harabasz_score, davies_bouldin_score
+   :members: fit, plot, from_data, from_centers, silhouette_score, calinski_harabasz_score, davies_bouldin_score, bokeh

--- a/environment.yml
+++ b/environment.yml
@@ -8,6 +8,7 @@ dependencies:
   - matplotlib
   - clustergram
   - seaborn
+  - bokeh
   - pip
   - pip:
     - urbangrammar-graphics


### PR DESCRIPTION
Adds `Clustergram.bokeh()` method which generates clustergram in a form of internactive bokeh plot. On top of an ability to zoom to specific sections shows the count of observations and cluster label (linked to `Clustergram.labels`).

To-do:
- [ ] documentation
- [x] check RAPIDS compatibility

I think I'll need to split docs into muliple pages at this point.