### PR TITLE
BUG: cluster centers empty due to index mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 Changelog
 =========
 
+Version 0.5.1 (May 24, 2021)
+----------------------------
+
+Bugfix for `from_data` method with non-default indices.
+
+Bugs:
+
+- BUG: cluster centers empty due to index mismatch (#19)
+
+
 Version 0.5.0 (May 11, 2021)
 ----------------------------
 

--- a/clustergram/clustergram.py
+++ b/clustergram/clustergram.py
@@ -471,9 +471,11 @@ class Clustergram:
 
         for i in cgram.k_range:
             if method == "mean":
-                cgram.cluster_centers[i] = data.groupby(labels[i]).mean().values
+                cgram.cluster_centers[i] = data.groupby(labels[i].values).mean().values
             elif method == "median":
-                cgram.cluster_centers[i] = data.groupby(labels[i]).median().values
+                cgram.cluster_centers[i] = (
+                    data.groupby(labels[i].values).median().values
+                )
             else:
                 raise ValueError(
                     f"'{method}' is not supported. Use 'mean' or 'median'."

--- a/clustergram/test_clustergram.py
+++ b/clustergram/test_clustergram.py
@@ -642,6 +642,20 @@ def test_from_data_nonsense():
         Clustergram.from_data(data, labels, method="nonsense")
 
 
+def test_from_data_index():
+    data = pd.DataFrame(
+        np.array([[-1, -1, 0, 10], [1, 1, 10, 2], [0, 0, 20, 4]]), index=["a", "b", "c"]
+    )
+    labels = pd.DataFrame({1: [0, 0, 0], 2: [0, 0, 1], 3: [0, 2, 1]})
+    clustergram = Clustergram.from_data(data, labels)
+    clustergram.plot()
+    clustergram.plot(pca_weighted=False)
+
+    clustergram = Clustergram.from_data(data, labels, method="median")
+    clustergram.plot()
+    clustergram.plot(pca_weighted=False)
+
+
 def test_from_centers():
     labels = pd.DataFrame({1: [0, 0, 0], 2: [0, 0, 1], 3: [0, 2, 1]})
     centers = {


### PR DESCRIPTION
If your `data` DataFrame has non-default index, `Clustergram.from_data` is broken. This fixes the issue and will go out as a quick bugfix release.